### PR TITLE
v1.0.8

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x, 1.14.x]
+        go-version: [1.14.x, 1.15.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/bufferpool.go
+++ b/bufferpool.go
@@ -79,7 +79,7 @@ func (b *BufferPool) autoGrow(data *bytes.Buffer) {
 }
 
 func (b *BufferPool) Put(data *bytes.Buffer) bool {
-	if b.maxBufSize <= data.Cap() {
+	if b.maxBufSize < data.Cap() {
 		// discard, dont keep too big size buffer in heap and release it
 		return false
 	}

--- a/bufferpool_test.go
+++ b/bufferpool_test.go
@@ -214,10 +214,10 @@ func TestBufferPoolDiscard(t *testing.T) {
 			tt.Errorf("maxBufSize put ng")
 		}
 
-		if p.Put(bytes.NewBuffer(make([]byte, 0, 30))) != true {
+		if p.Put(bytes.NewBuffer(make([]byte, 0, p.maxBufSize))) != true {
 			tt.Errorf("less than maxBufSize put no")
 		}
-		if p.Put(bytes.NewBuffer(make([]byte, 30))) != true {
+		if p.Put(bytes.NewBuffer(make([]byte, p.maxBufSize))) != true {
 			tt.Errorf("less than maxBufSize put no")
 		}
 	})

--- a/bufferpool_test.go
+++ b/bufferpool_test.go
@@ -190,14 +190,14 @@ func TestBufferPoolDiscard(t *testing.T) {
 			tt.Errorf("maxBufSize put ng")
 		}
 		if p.Put(bytes.NewBuffer(make([]byte, 100))) {
-			tt.Errorf("maxBufSie put ng")
+			tt.Errorf("maxBufSize put ng")
 		}
 
 		if p.Put(bytes.NewBuffer(make([]byte, 0, 30))) != true {
 			tt.Errorf("less than maxBufSize put no")
 		}
 		if p.Put(bytes.NewBuffer(make([]byte, 30))) != true {
-			tt.Errorf("less than maxBufSie put no")
+			tt.Errorf("less than maxBufSize put no")
 		}
 	})
 	t.Run("freecap/smallsize", func(tt *testing.T) {

--- a/bufferpool_test.go
+++ b/bufferpool_test.go
@@ -31,8 +31,10 @@ func BenchmarkBufferPool(b *testing.B) {
 		)
 	}
 	run("default/8", func(tb *testing.B) {
-		e := chanque.NewExecutor(10, 10)
-		defer e.Release()
+		tb.StopTimer()
+		e := chanque.NewExecutor(100, 100)
+		tb.Cleanup(func() { e.Release() })
+		tb.StartTimer()
 
 		for i := 0; i < tb.N; i += 1 {
 			e.Submit(func() {
@@ -42,8 +44,10 @@ func BenchmarkBufferPool(b *testing.B) {
 		}
 	})
 	run("default/4096", func(tb *testing.B) {
-		e := chanque.NewExecutor(10, 10)
-		defer e.Release()
+		tb.StopTimer()
+		e := chanque.NewExecutor(100, 100)
+		tb.Cleanup(func() { e.Release() })
+		tb.StartTimer()
 
 		for i := 0; i < tb.N; i += 1 {
 			e.Submit(func() {
@@ -53,8 +57,10 @@ func BenchmarkBufferPool(b *testing.B) {
 		}
 	})
 	run("syncpool/8", func(tb *testing.B) {
-		e := chanque.NewExecutor(10, 10)
-		defer e.Release()
+		tb.StopTimer()
+		e := chanque.NewExecutor(100, 100)
+		tb.Cleanup(func() { e.Release() })
+		tb.StartTimer()
 
 		p := &sync.Pool{
 			New: func() interface{} {
@@ -71,8 +77,10 @@ func BenchmarkBufferPool(b *testing.B) {
 		}
 	})
 	run("syncpool/4096", func(tb *testing.B) {
-		e := chanque.NewExecutor(10, 10)
-		defer e.Release()
+		tb.StopTimer()
+		e := chanque.NewExecutor(100, 100)
+		tb.Cleanup(func() { e.Release() })
+		tb.StartTimer()
 
 		p := &sync.Pool{
 			New: func() interface{} {
@@ -89,8 +97,10 @@ func BenchmarkBufferPool(b *testing.B) {
 		}
 	})
 	run("bufferpool/8", func(tb *testing.B) {
-		e := chanque.NewExecutor(10, 10)
-		defer e.Release()
+		tb.StopTimer()
+		e := chanque.NewExecutor(100, 100)
+		tb.Cleanup(func() { e.Release() })
+		tb.StartTimer()
 
 		p := NewBufferPool(e.MaxWorker(), 8)
 
@@ -103,8 +113,10 @@ func BenchmarkBufferPool(b *testing.B) {
 		}
 	})
 	run("bufferpool/4096", func(tb *testing.B) {
-		e := chanque.NewExecutor(10, 10)
-		defer e.Release()
+		tb.StopTimer()
+		e := chanque.NewExecutor(100, 100)
+		tb.Cleanup(func() { e.Release() })
+		tb.StartTimer()
 
 		p := NewBufferPool(e.MaxWorker(), 4096)
 

--- a/bytepool.go
+++ b/bytepool.go
@@ -59,7 +59,7 @@ func (b *BytePool) Get() []byte {
 }
 
 func (b *BytePool) Put(data []byte) bool {
-	if b.maxBufSize <= cap(data) {
+	if b.maxBufSize < cap(data) {
 		// discard, dont keep too big size byte in heap and release it
 		return false
 	}

--- a/bytepool_test.go
+++ b/bytepool_test.go
@@ -248,6 +248,7 @@ func TestBytePoolLenCap(t *testing.T) {
 			d := p.Get()
 			s = append(s, d)
 		}
+		// fill it
 		for _, d := range s {
 			p.Put(d)
 		}
@@ -259,6 +260,7 @@ func TestBytePoolLenCap(t *testing.T) {
 			tt.Errorf("max capacity = 10")
 		}
 
+		// discard it
 		d1 := make([]byte, bufSize)
 		d2 := make([]byte, bufSize)
 		p.Put(d1)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/octu0/bp
 
-go 1.13
+go 1.15
 
-require github.com/octu0/chanque v1.0.11
+require github.com/octu0/chanque v1.0.14

--- a/option.go
+++ b/option.go
@@ -5,7 +5,7 @@ type optionFunc func(*option)
 const (
 	defaultPreloadEnable    bool    = false
 	defaultPreloadRate      float64 = 0.25
-	defaultMaxBufSizeFactor float64 = 4.0
+	defaultMaxBufSizeFactor float64 = 1.25
 	defaultAutoGrowEnable   bool    = false
 )
 

--- a/option.go
+++ b/option.go
@@ -6,12 +6,14 @@ const (
 	defaultPreloadEnable    bool    = false
 	defaultPreloadRate      float64 = 0.25
 	defaultMaxBufSizeFactor float64 = 4.0
+	defaultAutoGrowEnable   bool    = false
 )
 
 type option struct {
 	preload          bool
 	preloadRate      float64
 	maxBufSizeFactor float64
+	autoGrow         bool
 }
 
 func newOption() *option {
@@ -19,6 +21,7 @@ func newOption() *option {
 		preload:          defaultPreloadEnable,
 		preloadRate:      defaultPreloadRate,
 		maxBufSizeFactor: defaultMaxBufSizeFactor,
+		autoGrow:         defaultAutoGrowEnable,
 	}
 }
 
@@ -37,5 +40,11 @@ func PreloadRate(rate float64) optionFunc {
 func MaxBufSizeFactor(factor float64) optionFunc {
 	return func(opt *option) {
 		opt.maxBufSizeFactor = factor
+	}
+}
+
+func AutoGrow(enable bool) optionFunc {
+	return func(opt *option) {
+		opt.autoGrow = enable
 	}
 }

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package bp
 
 const (
-	Version string = "1.0.7"
+	Version string = "1.0.8"
 )


### PR DESCRIPTION
- fix: where a `buffer` or `[]byte` with the same size as the max capacity was discarded.
- fix: not call bytes.Buffer.Grow by default
- decrease initial max grow factor size(4.0 to 1.25)